### PR TITLE
Added deterministic ordering of seeders

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ All seeders must be somewhere in the `seeds/` directory and inherit from `Seeder
 
 When all seeders have completed (successfully or not), Flask-Seeder will by default commit all changes to the database. This behaviour can be overridden with `--no-commit` or setting environment variable `FLASK_SEEDER_AUTOCOMMIT=0`.
 
+## Run Order
+
+When splitting seeders across multiple classes and files, order of operations is determined by two factors.
+First the seeders are grouped by `priority` (lower priority will be run first), all seeders with the same priority
+are then ordered by class name.
+
+See example below for setting priority on a seeder.
+
+```python
+from flask_seeder import Seeder
+
+class DemoSeeder(Seeder):
+  def __init__(self, db=None):
+    super().__init__(db=db)
+    self.priority = 10
+
+  def run(self):
+    ...
+```
+
 # Faker and Generators
 Flask-Seeder provides a `Faker` class that controls the creation of fake objects, based on real models. By telling `Faker` how to create the objects, you can easily create many different unique objects to help when seeding the database.
 

--- a/flask_seeder/cli.py
+++ b/flask_seeder/cli.py
@@ -7,6 +7,8 @@ import os
 import re
 import importlib.util
 import inspect
+from itertools import groupby, chain
+
 import click
 from flask.cli import with_appcontext
 from flask import current_app as app
@@ -119,7 +121,13 @@ def get_seeders(root=None):
     for script in scripts:
         seeders.extend(get_seeders_from_script(script))
 
-    return seeders
+    priority_key = lambda s: getattr(s, "priority", float("inf"))
+    sorted_seeders = (
+        sorted(g, key=priority_key)
+        for k, g in groupby(sorted(seeders, key=priority_key), key=priority_key)
+    )
+
+    return chain.from_iterable(sorted_seeders)
 
 
 @click.group()

--- a/flask_seeder/cli.py
+++ b/flask_seeder/cli.py
@@ -123,7 +123,7 @@ def get_seeders(root=None):
 
     priority_key = lambda s: getattr(s, "priority", float("inf"))
     sorted_seeders = (
-        sorted(g, key=priority_key)
+        sorted(g, key=lambda s: type(s).__name__)
         for k, g in groupby(sorted(seeders, key=priority_key), key=priority_key)
     )
 

--- a/flask_seeder/cli.py
+++ b/flask_seeder/cli.py
@@ -110,7 +110,7 @@ def get_seeders(root=None):
     Finds all python scripts with seeders, loads them and return them.
 
     Returns:
-        List of loaded seeder objects
+        Ordered list of loaded seeder objects based on priority and class name
     """
     seeders = []
     if root is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,12 +48,26 @@ class TestSeedCLI(TestCase):
 
     @patch("flask_seeder.cli.get_seed_scripts", return_value=["test"])
     @patch("flask_seeder.cli.get_seeders_from_script")
-    def test_get_seeders_return_list_of_seeders(self, m_get_seeders, m_get_scripts):
-        m_seeder = MagicMock()
-        m_get_seeders.return_value = [m_seeder]
-        expected_result = [m_seeder]
+    def test_get_seeders_return_ordered_iterable_of_seeders(self, m_get_seeders, m_get_scripts):
+        class TestSeeder:
+            def __init__(self, priority=None):
+                if priority:
+                    self.priority = priority
+        class QQTestSeeder:
+            def __init__(self, priority=None):
+                if priority:
+                    self.priority = priority
 
-        result = cli.get_seeders()
+        unordered_seeder_list = [TestSeeder(10), QQTestSeeder(), TestSeeder(), QQTestSeeder(1)]
+        m_get_seeders.return_value = unordered_seeder_list
+        expected_result = [
+            unordered_seeder_list[3],
+            unordered_seeder_list[0],
+            unordered_seeder_list[1],
+            unordered_seeder_list[2]
+        ]
+
+        result = list(cli.get_seeders())
 
         self.assertListEqual(result, expected_result)
 


### PR DESCRIPTION
Sometimes order matters, especially with foreign keys. This allows seeders to be split up across different seeders and different files with a guaranteed order of operations they will be executed in.

Ordering is first done by a priority key if it exists, and groups with the same priority are ordered by class name.